### PR TITLE
Python version adjusted

### DIFF
--- a/python/ticTacToe.py
+++ b/python/ticTacToe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from random import randint
 
 def connected(letter,board):


### PR DESCRIPTION
On some systems, like macOS, `python` links to python 2, while `python3` links to the latest python 3 release. On other systems however, like my Linux machine, both `python` and `python3` link to version 3. To avoid weird behavior with different versions, you should specify the one you want, which I assume is 3, so I've added this patch.